### PR TITLE
Fix compatibility with Ansible 2.9

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@
 # anonymous_ftp_incoming_data_dir:
 
 # Docker image to use for the FTP server
-anonymous_ftp_image: openmicroscopy/vsftpd-anonymous-upload:0.1.0
+anonymous_ftp_image: openmicroscopy/vsftpd-anonymous-upload:0.2.3
 
 # Group name/id for the uploads data directory
 anonymous_ftp_incoming_group: root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,7 +55,7 @@
     name: vsftpd
     published_ports: "{{ anonymous_ftp_published_ports }}"
     state: started
-    restart: "{{ _anonymous_ftp_config | changed }}"
+    restart: "{{ _anonymous_ftp_config is changed }}"
     restart_policy: always
     volumes:
       - "{{ anonymous_ftp_incoming_data_dir }}:/var/lib/ftp/incoming"


### PR DESCRIPTION
See https://github.com/IDR/deployment/pull/361
Also bumps the default version of the Docker image to 0.2.3 including OS upgrade and the segfault fix