### PR TITLE
Use python3-docker package instead of pip package

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,6 +31,19 @@
     - vsftpd.email_passwords
   register: _anonymous_ftp_config
 
+- name: Import a key for epel
+  ansible.builtin.rpm_key:
+    state: present
+    key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9
+
+- name: Setup dnf repository, epel
+  become: true
+  ansible.builtin.dnf:
+    update_cache: true
+    name:
+      https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+    state: present
+
 - name: Install docker
   become: true
   yum:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,7 +46,7 @@
 
 - name: Install docker
   become: true
-  yum:
+  ansible.builtin.dnf:
     name: python3-docker
     state: present
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,8 +33,8 @@
 
 - name: Install docker
   become: true
-  ansible.builtin.pip:
-    name: docker
+  yum:
+    name: python3-docker
     state: present
 
 - name: Get Docker published ports list


### PR DESCRIPTION
While trying to use the `ome.anonymous_ftp 0.2.0` role to upgrade IDR FTP service, I came across this error:

```
TASK [ome.anonymous_ftp : Install docker] ******************************************************************************************************************************************************************************
fatal: [upload-ftp]: FAILED! => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python3.9"}, "changed": false, "cmd": ["/usr/bin/python3.9", "-m", "pip.__main__", "install", "docker"], "msg": "\n:stderr: /usr/bin/python3.9: Error while finding module specification for 'pip.__main__' (ModuleNotFoundError: No module named 'pip')\n"}
```

Rather than depending on global Python packages, this proposes to use the system `docker3-python` package available from EPEL repositories (which are already used across our roles)